### PR TITLE
Allow other services for smushit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ brew install optipng jpeg
     smushit: false # if false it use jpegtran and optipng, if set to true it will use smushit
     path: 'images' # your image path within your public folder
 ```
+You can also pass a specific service with smushit
+```coffeescript
+  imageoptimizer:
+    smushit:
+      service: 'http://api.resmush.it/ws.php' # uses api.resmush.it instead of Yahoo
+    path: 'images' # your image path within your public folder
+```
 
 ## Usage
 Add `"imageoptmizer-brunch": "0.0.4"` to `package.json` of your brunch app.

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,7 +30,7 @@ module.exports = class ImageOptimzer
     return unless fs.existsSync(@imagePath)
 
     if @config.plugins?.imageoptimizer?.smushit
-      smushit.smushit @imagePath, recursive: true
+      smushit.smushit @imagePath, recursive: true, service: @config.plugins?.imageoptimizer?.smushit.service
     else
       files = @readDirSync(@imagePath)
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,7 +30,9 @@ module.exports = class ImageOptimzer
     return unless fs.existsSync(@imagePath)
 
     if @config.plugins?.imageoptimizer?.smushit
-      smushit.smushit @imagePath, recursive: true, service: @config.plugins?.imageoptimizer?.smushit.service
+      smushit.smushit @imagePath,
+        recursive: true,
+        service: @config.plugins?.imageoptimizer?.smushit.service || ''
     else
       files = @readDirSync(@imagePath)
 


### PR DESCRIPTION
Currently, brunch plugin only uses the default smushit. This PR will allow other services to be passed (Yahoo service can sometimes return corrupted images).